### PR TITLE
Smarter conversion dicts

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -12,6 +12,7 @@
 # meter in inches
 # m in in
 
+from __future__ import print_function
 from subprocess import Popen, PIPE
 import sys
 import os
@@ -223,7 +224,7 @@ energies_dictionary = {}
 energies_dictionary["hartree"] = "au"
 energies_dictionary["kcal"] = "kcal/mol"
 
-energies_keys = energies.keys() + energies_dictionary.keys()
+energies_keys = list(energies.keys()) + list(energies_dictionary.keys())
 
 
 def shell(cmd, shell=False):
@@ -290,7 +291,7 @@ after creating an APP API, dump the key in
 
     # TODO format the | columns from the output
 
-    print data["queryresult"]["pod"][1]["subpod"]["plaintext"]
+    print(data["queryresult"]["pod"][1]["subpod"]["plaintext"])
     quit()
 
 
@@ -318,7 +319,7 @@ def convert_currency(value, fr, to):
     google = shell('wget -qO- "http://www.google.com/finance/converter?a='+value+'&from='+fr+'&to='+to+'" | sed "/res/!d;s/<[^>]*>//g";', shell=True)
     google = google.strip()
     if google == "": exit("Could not recognize currency: "+" ".join(args))
-    print google
+    print(google)
 
 
 def convert_energy(value, unit_a, unit_b):
@@ -331,7 +332,7 @@ def convert_energy(value, unit_a, unit_b):
 
     value = float(value)
     value = value*energies[unit_a][unit_b]
-    print value, unit_b
+    print(str(value) + str(unit_b))
 
 
 if __name__ == '__main__':
@@ -376,6 +377,4 @@ Question (Using wolfram alpha)
         quit()
 
     # Evaluate argument as Python math
-    print eval(" ".join(args))
-
-
+    print(eval(" ".join(args)))

--- a/convert.py
+++ b/convert.py
@@ -22,6 +22,9 @@ import re
 import urllib
 import xmltodict
 
+from utils import CaseInsensitiveDict
+
+
 try:
     # For Python 3.0 and later
     from urllib.request import urlopen
@@ -206,25 +209,17 @@ currencies["ZWL"] = "Zimbabwean Dollar (2009) (ZWL)"
 # TODO KiloJoule, cm**(-1)
 # http://users.mccammon.ucsd.edu/~dzhang/energy-unit-conv-table.html
 
-energies = {}
-energies["au"] = {}
-energies["ev"] = {}
-energies["kcal/mol"] = {}
+# For each energy unit, we note it's value in Joule
+energies = CaseInsensitiveDict()
+energies["J"] = 1
+energies["au"] = 4.359745e-18
+energies["eV"] = 1.6021766e-19
+energies["kcal/mol"] = 6.9476e-21
 
-energies["au"]["ev"] = 27.211396641
-energies["ev"]["au"] = 1.0/energies["au"]["ev"]
-
-energies["au"]["kcal/mol"] = 627.509 # kcal mol-1
-energies["kcal/mol"]["au"] = 1.0/energies["au"]["kcal/mol"]
-
-energies["kcal/mol"]["ev"] = 0.0433634
-energies["ev"]["kcal/mol"] = 1.0/energies["kcal/mol"]["ev"]
-
-energies_dictionary = {}
-energies_dictionary["hartree"] = "au"
-energies_dictionary["kcal"] = "kcal/mol"
-
-energies_keys = list(energies.keys()) + list(energies_dictionary.keys())
+# Alternative names
+energies["hartree"] = energies["au"]
+energies["Ha"] = energies["au"]
+energies["kcal"] = energies["kcal/mol"]
 
 
 def shell(cmd, shell=False):
@@ -302,7 +297,7 @@ def find_converter(args):
     unit_b = args[3]
 
     # Energy
-    if unit_a in energies_keys and unit_b in energies_keys:
+    if unit_a in energies and unit_b in energies:
         convert_energy(value, unit_a, unit_b)
         quit()
 
@@ -323,16 +318,10 @@ def convert_currency(value, fr, to):
 
 
 def convert_energy(value, unit_a, unit_b):
-
-    if unit_a in energies_dictionary.keys():
-        unit_a = energies_dictionary[unit_a]
-
-    if unit_b in energies_dictionary.keys():
-        unit_b = energies_dictionary[unit_b]
-
     value = float(value)
-    value = value*energies[unit_a][unit_b]
-    print(str(value) + str(unit_b))
+    conversion_factor = energies[unit_a] / energies[unit_b]
+    value = value*conversion_factor
+    print("{} {}".format(value, unit_b))
 
 
 if __name__ == '__main__':

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,72 @@
+import collections
+
+# Copied from https://github.com/kennethreitz/requests
+# https://github.com/kennethreitz/requests/blob/v1.2.3/requests/structures.py#L37
+
+class CaseInsensitiveDict(collections.MutableMapping):
+    """
+    A case-insensitive ``dict``-like object.
+    Implements all methods and operations of
+    ``collections.MutableMapping`` as well as dict's ``copy``. Also
+    provides ``lower_items``.
+    All keys are expected to be strings. The structure remembers the
+    case of the last key to be set, and ``iter(instance)``,
+    ``keys()``, ``items()``, ``iterkeys()``, and ``iteritems()``
+    will contain case-sensitive keys. However, querying and contains
+    testing is case insensitive:
+        cid = CaseInsensitiveDict()
+        cid['Accept'] = 'application/json'
+        cid['aCCEPT'] == 'application/json'  # True
+        list(cid) == ['Accept']  # True
+    For example, ``headers['content-encoding']`` will return the
+    value of a ``'Content-Encoding'`` response header, regardless
+    of how the header name was originally stored.
+    If the constructor, ``.update``, or equality comparison
+    operations are given keys that have equal ``.lower()``s, the
+    behavior is undefined.
+    """
+    def __init__(self, data=None, **kwargs):
+        self._store = dict()
+        if data is None:
+            data = {}
+        self.update(data, **kwargs)
+
+    def __setitem__(self, key, value):
+        # Use the lowercased key for lookups, but store the actual
+        # key alongside the value.
+        self._store[key.lower()] = (key, value)
+
+    def __getitem__(self, key):
+        return self._store[key.lower()][1]
+
+    def __delitem__(self, key):
+        del self._store[key.lower()]
+
+    def __iter__(self):
+        return (casedkey for casedkey, mappedvalue in self._store.values())
+
+    def __len__(self):
+        return len(self._store)
+
+    def lower_items(self):
+        """Like iteritems(), but with all lowercase keys."""
+        return (
+            (lowerkey, keyval[1])
+            for (lowerkey, keyval)
+            in self._store.items()
+        )
+
+    def __eq__(self, other):
+        if isinstance(other, collections.Mapping):
+            other = CaseInsensitiveDict(other)
+        else:
+            return NotImplemented
+        # Compare insensitively
+        return dict(self.lower_items()) == dict(other.lower_items())
+
+    # Copy is required
+    def copy(self):
+         return CaseInsensitiveDict(self._store.values())
+
+    def __repr__(self):
+        return '%s(%r)' % (self.__class__.__name__, dict(self.items()))


### PR DESCRIPTION
Added case insensitive dictionary, and refactored energy conversions
It is useful to be able to convert both ev and eV, without both being explicitly
added to the dictionary. I added CaseInsensitiveDict found in the `requests`
library.

I also refactored the way we actually convert the energy. The dictionary
now just holds the conversion to SI units, and then we only need to store
one number per unit we care about.